### PR TITLE
Being a little more PL/Java-esque

### DIFF
--- a/pljava/part1/README.md
+++ b/pljava/part1/README.md
@@ -239,7 +239,7 @@ What did the final **true** in that “**install_jar**” do? Nothing. But we’
 The next step is to create the Postgres functions:
 
 ```sql
-demo=# CREATE FUNCTION getCustomerInfo( INT ) RETURNS CHAR AS 
+demo=# CREATE FUNCTION getCustomerInfo( INT ) RETURNS VARCHAR AS 
     'com.percona.blog.pljava.Customers.getCustomerInfo( java.lang.Integer )'
 LANGUAGE java;
 CREATE FUNCTION
@@ -363,7 +363,7 @@ demo=# SELECT sqlj.replace_jar( 'file:///app/pg12/lib/demo.jar', 'demo', true );
 -------------
 (1 row)
 
-demo=# CREATE FUNCTION getCustomerTotal( INT ) RETURNS CHAR AS 
+demo=# CREATE FUNCTION getCustomerTotal( INT ) RETURNS VARCHAR AS 
     'com.percona.blog.pljava.Customers.getCustomerTotal( java.lang.Integer )'
 LANGUAGE java;
 CREATE FUNCTION
@@ -417,10 +417,10 @@ That would mean writing them in a “deployment descriptor” file, normally wit
 $ cat demo.ddr
 SQLActions[]={
 "BEGIN INSTALL
-CREATE FUNCTION getCustomerInfo( INT ) RETURNS CHAR AS
+CREATE FUNCTION getCustomerInfo( INT ) RETURNS VARCHAR AS
     'com.percona.blog.pljava.Customers.getCustomerInfo( java.lang.Integer )'
 LANGUAGE java;
-CREATE FUNCTION getCustomerTotal( INT ) RETURNS CHAR AS
+CREATE FUNCTION getCustomerTotal( INT ) RETURNS VARCHAR AS
     'com.percona.blog.pljava.Customers.getCustomerTotal( java.lang.Integer )'
 LANGUAGE java;
 END INSTALL",

--- a/pljava/part1/src/demo.ddr
+++ b/pljava/part1/src/demo.ddr
@@ -1,0 +1,14 @@
+SQLActions[]={
+"BEGIN INSTALL
+CREATE FUNCTION getCustomerInfo( INT ) RETURNS CHAR AS
+    'com.percona.blog.pljava.Customers.getCustomerInfo( java.lang.Integer )'
+LANGUAGE java;
+CREATE FUNCTION getCustomerTotal( INT ) RETURNS CHAR AS
+    'com.percona.blog.pljava.Customers.getCustomerTotal( java.lang.Integer )'
+LANGUAGE java;
+END INSTALL",
+"BEGIN REMOVE
+DROP FUNCTION getCustomerInfo( INT );
+DROP FUNCTION getCustomerTotal( INT );
+END REMOVE"
+}

--- a/pljava/part1/src/demo.mf
+++ b/pljava/part1/src/demo.mf
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Name: demo.ddr
+SQLJDeploymentDescriptor: TRUE

--- a/pljava/part2/src/com/percona/blog/pljava/CustomerCrypto.java
+++ b/pljava/part2/src/com/percona/blog/pljava/CustomerCrypto.java
@@ -23,6 +23,7 @@ import org.postgresql.pljava.annotation.Function;
 import org.postgresql.pljava.annotation.Trigger;
 import static org.postgresql.pljava.annotation.Trigger.Called.BEFORE;
 import static org.postgresql.pljava.annotation.Trigger.Event.INSERT;
+import static org.postgresql.pljava.annotation.Trigger.Event.UPDATE;
 import static org.postgresql.pljava.annotation.Trigger.Scope.ROW;
 
 public class CustomerCrypto implements ResultSetProvider {
@@ -51,7 +52,7 @@ public class CustomerCrypto implements ResultSetProvider {
 	
 	public void processQuery(int id) throws SQLException, NoSuchAlgorithmException {
 		String query;
-		query = "SELECT * FROM customer2 WHERE customer_id = ?";
+		query = "SELECT * FROM customer WHERE customer_id = ?";
 		stmt = conn.prepareStatement(query);
 		stmt.setInt(1, id);
 		rs = stmt.executeQuery();
@@ -100,8 +101,8 @@ public class CustomerCrypto implements ResultSetProvider {
 	
 	@Function(
 		triggers = @Trigger(
-			called = BEFORE, events = INSERT, scope = ROW,
-			table = "customer",
+			called = BEFORE, events = { INSERT, UPDATE },
+			scope = ROW, table = "customer",
 			name = "tg_customerBeforeInsertUpdate"
 		)
 	)

--- a/pljava/part2/src/com/percona/blog/pljava/CustomerCrypto.java
+++ b/pljava/part2/src/com/percona/blog/pljava/CustomerCrypto.java
@@ -19,6 +19,12 @@ import javax.crypto.NoSuchPaddingException;
 import org.postgresql.pljava.ResultSetProvider;
 import org.postgresql.pljava.TriggerData;
 
+import org.postgresql.pljava.annotation.Function;
+import org.postgresql.pljava.annotation.Trigger;
+import static org.postgresql.pljava.annotation.Trigger.Called.BEFORE;
+import static org.postgresql.pljava.annotation.Trigger.Event.INSERT;
+import static org.postgresql.pljava.annotation.Trigger.Scope.ROW;
+
 public class CustomerCrypto implements ResultSetProvider {
 	private final String m_url = "jdbc:default:connection";
 	private final Connection conn;
@@ -92,11 +98,19 @@ public class CustomerCrypto implements ResultSetProvider {
 		_new.updateString("email", Crypto.encrypt(_new.getString("email"), this.publicKey));
 	}
 	
+	@Function(
+		triggers = @Trigger(
+			called = BEFORE, events = INSERT, scope = ROW,
+			table = "customer",
+			name = "tg_customerBeforeInsertUpdate"
+		)
+	)
 	public static void customerBeforeInsertUpdate(TriggerData td) throws SQLException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException, NoSuchPaddingException, NoSuchAlgorithmException {
 		CustomerCrypto ret = new CustomerCrypto();
 		ret.encryptData(td);
 	}
 
+	@Function(type = "customer")
 	public static ResultSetProvider getCustomerCrypto(int id) throws SQLException, NoSuchAlgorithmException {
 		CustomerCrypto ret = new CustomerCrypto();
 		ret.processQuery(id);

--- a/pljava/part2/src/com/percona/blog/pljava/CustomerHash.java
+++ b/pljava/part2/src/com/percona/blog/pljava/CustomerHash.java
@@ -11,6 +11,8 @@ import java.util.logging.Logger;
 
 import org.postgresql.pljava.ResultSetProvider;
 
+import org.postgresql.pljava.annotation.Function;
+
 public class CustomerHash implements ResultSetProvider {
 	private final Connection conn;
 	private final PreparedStatement stmt;
@@ -59,6 +61,7 @@ public class CustomerHash implements ResultSetProvider {
 		return true;
 	}
 	
+	@Function(type = "customer")
 	public static ResultSetProvider getCustomerAnonymized(int id) throws SQLException, NoSuchAlgorithmException {
 		return new CustomerHash(id);
 	}

--- a/pljava/part2/src/com/percona/blog/pljava/CustomerResultSet.java
+++ b/pljava/part2/src/com/percona/blog/pljava/CustomerResultSet.java
@@ -8,6 +8,8 @@ import java.sql.SQLException;
 
 import org.postgresql.pljava.ResultSetHandle;
 
+import org.postgresql.pljava.annotation.Function;
+
 public class CustomerResultSet implements ResultSetHandle {
 	private Connection conn;
 	private PreparedStatement stmt;
@@ -30,6 +32,7 @@ public class CustomerResultSet implements ResultSetHandle {
 		return stmt.executeQuery();
 	}
 
+	@Function(type = "customer")
 	public static ResultSetHandle getCustomerLimit10() throws SQLException {
 		return new CustomerResultSet();
 	}

--- a/pljava/part2/src/demo.mf
+++ b/pljava/part2/src/demo.mf
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Name: pljava.ddr
+SQLJDeploymentDescriptor: TRUE


### PR DESCRIPTION
Hi there,

Thanks for the thorough blog posts on PL/Java! I will be interested to see part 3 when it is ready.

I thought I would suggest a few things that could be covered where PL/Java can help more with the SQL commands that are being written manually in your examples. I also found a couple things I think were typos in the blog posts. (One of them was a useful typo, because the fact that the example even works with return type `CHAR` reveals a PL/Java bug I hadn't known about!)

Letting PL/Java do the SQL generation has more benefits than just saving some work. It makes sure the SQL stays up to date with changes to the Java sources. You can see the declaration details right in the sources. The compiler doesn't just generate SQL blindly, it knows the rules for what is valid in Postgres, so it can catch many mistakes right at compile time, not later when you load things into the database. And if you do your Java coding in an IDE and it has the PL/Java API jar on its classpath, it can guide you through the details as you code.

(On the downside, I would never have learned about that bug with `CHAR` that way, because the generated SQL would have had the expected `VARCHAR` type.)

I put this in the form of a pull request just because that's easy to do. Of course I am not thinking you'd necessarily want to merge somebody else's words right into your own blog posts. :) (I also won't mind if you do—that's up to you.) It's just the easiest way to show my suggestions in the context of the original posts.

I also changed the PL/Java version to 1.6.3 just because, hey, it's released now.

As you start part 1 by searching for good resources on the internet, I wonder if you found [this old article][bgudts] by Bear Giles. It is about defining new Postgres data types, which complements your posts here since you are covering different topics. His code for that article is [also on GitHub][bggh]. Because he wrote it back in 2012, it also doesn't use the PL/Java annotations and SQL generation (didn't exist then), and it also has a pull request beargiles/pljava-udt-type-extension#6 showing how much simpler it gets using the annotations. I've kept updating the pull request over the years as newer PL/Java versions can automatically handle more parts of his example. He doesn't actually merge the PR, it's just always available to refer to, so you can see his original code, or see the way it would look in modern PL/Java, or step through the commits in the PR and see the changes step by step.

[bgudts]: https://web.archive.org/web/20150808065525/http://invariantproperties.com/2012/01/02/introduction-to-postgresql-pljava-part-4-user-defined-types/
[bggh]: https://github.com/beargiles/pljava-udt-type-extension